### PR TITLE
missing "jackfruit" in union for Sandwich protein in ex-3 solution

### DIFF
--- a/solutions/ex-3.ts
+++ b/solutions/ex-3.ts
@@ -43,7 +43,7 @@ interface Taco {
   
   export interface Sandwich {
     type: "sandwich";
-    protein: "chicken" | "portabelloCap";
+    protein: "chicken" | "jackfruit" | "portabelloCap";
     toppings: Topping[];
   }
   


### PR DESCRIPTION
Thanks for the exercises!

I noticed a small discrepancy between the menu and the solution type for ex-3. "jackfruit" should be permitted as a sandwich protein.